### PR TITLE
Change all characters in Rakefile to be ASCII only

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,7 @@ namespace :view do
   task :xip do
     ip = `ifconfig | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | awk '{ printf "%s", $0 }'`
     url = "http://#{url_pow}.#{ip}.xip.io/"
-    puts "Opening #{url}…"
+    puts "Opening #{url}..."
     system "open #{url}"
   end
 
@@ -99,10 +99,10 @@ namespace :view do
     system "open http://github.com/#{github_repo}"
   end
 
-  desc "A quick glimpse at your GitHub repo’s watchers, stars, and forks."
+  desc "A quick glimpse at your GitHub repo's watchers, stars, and forks."
   namespace :github do
     task :stats do
-      puts "Downloading GitHub repo data through their API…"
+      puts "Downloading GitHub repo data through their API..."
       json = `curl https://api.github.com/repos/#{github_repo}`
       repo = JSON.parse(json)
       puts ""


### PR DESCRIPTION
The ruby linter chokes on non ascii characters without a hint to interpret the file as UTF-8. This change seemed a reasonable way to fix it. If you'd prefer, you can add  `# encoding: utf-8` to the top of the file and keep the nice glyphs.
